### PR TITLE
perms: allow org.kde.StatusNotifierWatcher for tray icon

### DIFF
--- a/io.ente.photos.yml
+++ b/io.ente.photos.yml
@@ -14,6 +14,7 @@ finish-args:
   - --device=dri
   - --share=network
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.StatusNotifierWatcher
 
 modules:
   - name: libsecret


### PR DESCRIPTION
Otherwise, ente runs in the background, with no indication of it happening. Check with `flatpak ps`.

This permission may allow a sandbox escape (https://github.com/netblue30/firejail/discussions/4053)