### PR TITLE
fix: add kwallet perms so that Ente photos can store secrets in the user's wallet

### DIFF
--- a/io.ente.photos.yml
+++ b/io.ente.photos.yml
@@ -15,6 +15,8 @@ finish-args:
   - --share=network
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
 
 modules:
   - name: libsecret


### PR DESCRIPTION
This PR adds two more permissions so that Ente can access KWallet on KDE. 

The Chromium Flatpak has these two permissions too:
https://github.com/flathub/org.chromium.Chromium/blob/6388dc0e97e1f536fefde18fd9f58f9f881d7636/org.chromium.Chromium.yaml#L28-L29

Fixes https://github.com/flathub/io.ente.photos/issues/8