### PR TITLE
fix: set TMPDIR environment variable so that the tray icon gets bundled

### DIFF
--- a/io.ente.photos.yml
+++ b/io.ente.photos.yml
@@ -80,4 +80,7 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - zypak-wrapper.sh /app/ente/ente "$@"
+          - set -o errexit
+          - TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
+          - export TMPDIR
+          - exec zypak-wrapper.sh /app/ente/ente "$@"


### PR DESCRIPTION
The tray icon appears as a three dots on GNOME (I don't know if in other DEs):

![image](https://github.com/user-attachments/assets/722c1136-873c-4f20-a8c9-8808318f1548)

This fix enables the tray icon:

![image](https://github.com/user-attachments/assets/0c6967f6-f626-4671-9dc0-88d3f2161a07)

See https://github.com/flathub/com.sindresorhus.Caprine/commit/bea72c8e6e5c639cea0bca2399514b056b98d764