### PR TITLE
Add audio & system bus access

### DIFF
--- a/io.ente.photos.yml
+++ b/io.ente.photos.yml
@@ -12,7 +12,6 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=pulseaudio
-  - --socket=system-bus
   - --device=dri
   - --share=network
   - --talk-name=org.freedesktop.secrets

--- a/io.ente.photos.yml
+++ b/io.ente.photos.yml
@@ -11,6 +11,8 @@ rename-icon: ente
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --socket=pulseaudio
+  - --socket=system-bus
   - --device=dri
   - --share=network
   - --talk-name=org.freedesktop.secrets


### PR DESCRIPTION
It is very dissapointing to see that Pulseaudio socket was not added initially; because videos among other media on Ente have sound.
As for the system bus access, it is because of these errors:
```
[2:0513/170438.842290:ERROR:bus.cc(408)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[2:0513/170438.842326:ERROR:bus.cc(408)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
```

Does no one really use this flatpak?